### PR TITLE
Fixed mouse over issue

### DIFF
--- a/kz-snackbar.js
+++ b/kz-snackbar.js
@@ -1,17 +1,32 @@
+var timer;
+
 function showKzSnackbar(text,duration,isVisible) {
 	var kzsnackbar = document.getElementById('kz-snackbar');
 	var kzcontent = document.getElementById('kz-content');
-	
+
+	function clearKzTimeout(){
+		//clear previous message's hider timeout
+		clearTimeout(timer);
+	}
+
+	function setKzTimeout(){
+		timer = setTimeout(function() {
+			var clientHeight = document.getElementById('kz-snackbar').clientHeight;
+			kzsnackbar.style.bottom = "-" + clientHeight + "px";
+		}, duration);
+	}
+
+	clearKzTimeout();
+	kzsnackbar.addEventListener("mouseenter", clearKzTimeout);
+	kzsnackbar.addEventListener("mouseleave", setKzTimeout);
+
 	if (text == null || duration == null || isVisible == null) {
 		alert('Calling mismatch. There is/are missing variable(s).');
 	} else {
 		if (kzsnackbar.style.bottom !== "0") {
 			kzsnackbar.style.bottom = "0";
 			kzcontent.innerHTML = text;
-			setTimeout(function() {
-				var clientHeight = document.getElementById('kz-snackbar').clientHeight;
-				kzsnackbar.style.bottom = "-" + clientHeight + "px";
-			}, duration*1000);
+			setKzTimeout();
 		};
 		
 		if (isVisible) {

--- a/sample.md
+++ b/sample.md
@@ -3,14 +3,14 @@ permalink: /sample
 ---
 
 <div id="kz-snackbar" class="kz-snackbar">
-	<link rel="stylesheet" href="https://berkantkz.github.io/KzSnackbar/kz-snackbar.css" />
-	<script src="https://berkantkz.github.io/KzSnackbar/kz-snackbar.js"></script>
+	<link rel="stylesheet" href="kz-snackbar.css" />
+	<script src="kz-snackbar.js"></script>
 	<p id="kz-content"></p>
 	<button id="kz-close" onclick="closeKzSnackbar()">x</button>
 </div>
 
-<p onclick="showKzSnackbar('Here is a snackbar with close button!',2,true)">Click me to see with close button!</p>
-<p onclick="showKzSnackbar('And here is another one without close button!',2,false)">Click me to see without close button!</p>
+<p onclick="showKzSnackbar('Here is a snackbar with close button!',2000,true)">Click me to see with close button!</p>
+<p onclick="showKzSnackbar('And here is another one without close button!',2000,false)">Click me to see without close button!</p>
 
 <br>
 * berkantkz


### PR DESCRIPTION
From now on, when mouse is on top of snackbar, it will not disappear.
Converted duration to miliseconds.
Simplified sample.md import links.